### PR TITLE
feat: add `essential-builder-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,10 @@ dependencies = [
 
 [[package]]
 name = "essential-builder"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "essential-builder-db",
+ "essential-builder-types",
  "essential-check",
  "essential-hash",
  "essential-node",
@@ -591,11 +592,12 @@ dependencies = [
 
 [[package]]
 name = "essential-builder-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "essential-builder-api",
  "essential-builder-db",
+ "essential-builder-types",
  "essential-hash",
  "essential-node",
  "essential-types",
@@ -638,8 +640,9 @@ dependencies = [
 
 [[package]]
 name = "essential-builder-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "essential-builder-types",
  "essential-hash",
  "essential-types",
  "num_cpus",
@@ -649,6 +652,14 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "essential-builder-types"
+version = "0.1.0"
+dependencies = [
+ "essential-types",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 
-essential-builder = { path = "crates/builder", version = "0.1.0" }
-essential-builder-api = { path = "crates/builder-api", version = "0.1.0" }
-essential-builder-db = { path = "crates/builder-db", version = "0.1.0" }
+essential-builder = { path = "crates/builder", version = "0.2.0" }
+essential-builder-api = { path = "crates/builder-api", version = "0.2.0" }
+essential-builder-db = { path = "crates/builder-db", version = "0.2.0" }
+essential-builder-types = { path = "crates/builder-types", version = "0.1.0" }

--- a/crates/builder-api/Cargo.toml
+++ b/crates/builder-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-builder-api"
 description = "API implementation for the Essential builder"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 axum = { workspace = true }
 essential-builder-db = { workspace = true }
+essential-builder-types = { workspace = true }
 essential-types = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/crates/builder-api/src/endpoint.rs
+++ b/crates/builder-api/src/endpoint.rs
@@ -53,7 +53,7 @@ pub mod health_check {
 /// at most `limit` (or [`latest_solution_failures::MAX_LIMIT`] - whatever's lowest) of
 /// the latest failures for the associated solution.
 pub mod latest_solution_failures {
-    use essential_builder_db::SolutionFailure;
+    use essential_builder_types::SolutionFailure;
     pub const MAX_LIMIT: u32 = 10;
     use super::*;
     pub const PATH: &str = "/latest_solution_failures/:solution_ca/:limit";

--- a/crates/builder-api/tests/endpoint.rs
+++ b/crates/builder-api/tests/endpoint.rs
@@ -1,5 +1,5 @@
 use essential_builder_api as builder_api;
-use essential_builder_db::SolutionFailure;
+use essential_builder_types::SolutionFailure;
 use essential_node::test_utils as test_util;
 use essential_types::ContentAddress;
 use std::{sync::Arc, time::Duration};

--- a/crates/builder-db/Cargo.toml
+++ b/crates/builder-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-builder-db"
 description = "The Essential builder database"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+essential-builder-types = { workspace = true }
 essential-hash = { workspace = true }
 essential-types = { workspace = true }
 num_cpus = { workspace = true, optional = true }

--- a/crates/builder-db/src/lib.rs
+++ b/crates/builder-db/src/lib.rs
@@ -19,6 +19,7 @@
 //!   stored number is within a given limit.
 
 use error::{DecodeError, QueryError};
+use essential_builder_types::SolutionFailure;
 use essential_hash::content_addr;
 use essential_types::{solution::Solution, ContentAddress, Hash};
 #[cfg(feature = "pool")]
@@ -31,22 +32,6 @@ pub mod error;
 #[cfg(feature = "pool")]
 pub mod pool;
 pub mod sql;
-
-/// A failed attempt at applying a solution at a particular location within a particular block.
-///
-/// The builder stores these in order to provide solution submitters feedback in the case that a
-/// solution could not be applied trivially and did not make it into a block.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct SolutionFailure<'a> {
-    /// The number of the block in which the builder attempted to apply the solution.
-    pub attempt_block_num: i64,
-    /// The address of the block in which the builder attempted to apply the solution.
-    pub attempt_block_addr: ContentAddress,
-    /// The solution index within the block at which the builder attempted to apply the solution.
-    pub attempt_solution_ix: u32,
-    /// An error message describing why the builder failed to apply the solution.
-    pub err_msg: std::borrow::Cow<'a, str>,
-}
 
 /// Encodes the given value into a blob.
 ///

--- a/crates/builder-db/tests/delete.rs
+++ b/crates/builder-db/tests/delete.rs
@@ -1,4 +1,5 @@
-use essential_builder_db::{self as builder_db, SolutionFailure};
+use essential_builder_db::{self as builder_db};
+use essential_builder_types::SolutionFailure;
 use rusqlite::Connection;
 use std::time::Duration;
 

--- a/crates/builder-db/tests/insert.rs
+++ b/crates/builder-db/tests/insert.rs
@@ -1,4 +1,5 @@
 use essential_builder_db as builder_db;
+use essential_builder_types::SolutionFailure;
 use rusqlite::Connection;
 
 mod util;
@@ -44,7 +45,7 @@ fn insert_solution_failure() {
     tx.commit().unwrap();
 
     // Insert a solution failure.
-    let failure = builder_db::SolutionFailure {
+    let failure = SolutionFailure {
         attempt_block_num: 1,
         attempt_block_addr: block_ca,
         attempt_solution_ix: 0,

--- a/crates/builder-db/tests/query.rs
+++ b/crates/builder-db/tests/query.rs
@@ -1,4 +1,5 @@
-use essential_builder_db::{self as builder_db, SolutionFailure};
+use essential_builder_db::{self as builder_db};
+use essential_builder_types::SolutionFailure;
 use rusqlite::Connection;
 use std::time::Duration;
 

--- a/crates/builder-types/Cargo.toml
+++ b/crates/builder-types/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "essential-builder-types"
+description = "The Essential builder types"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+essential-types = { workspace = true }
+serde = { workspace = true }

--- a/crates/builder-types/README.md
+++ b/crates/builder-types/README.md
@@ -1,0 +1,17 @@
+# essential-builder-types
+
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![license][apache-badge]][apache-url]
+[![Build Status][actions-badge]][actions-url]
+
+[crates-badge]: https://img.shields.io/crates/v/essential-builder-types.svg
+[crates-url]: https://crates.io/crates/essential-builder-types
+[docs-badge]: https://docs.rs/essential-builder-types/badge.svg
+[docs-url]: https://docs.rs/essential-builder-types
+[apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
+[apache-url]: LICENSE
+[actions-badge]: https://github.com/essential-contributions/essential-builder/workflows/ci/badge.svg
+[actions-url]: https://github.com/essential-contributions/essential-builder/actions
+
+The Essential builder types.

--- a/crates/builder-types/src/lib.rs
+++ b/crates/builder-types/src/lib.rs
@@ -1,0 +1,18 @@
+use essential_types::ContentAddress;
+use serde::{Deserialize, Serialize};
+
+/// A failed attempt at applying a solution at a particular location within a particular block.
+///
+/// The builder stores these in order to provide solution submitters feedback in the case that a
+/// solution could not be applied trivially and did not make it into a block.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct SolutionFailure<'a> {
+    /// The number of the block in which the builder attempted to apply the solution.
+    pub attempt_block_num: i64,
+    /// The address of the block in which the builder attempted to apply the solution.
+    pub attempt_block_addr: ContentAddress,
+    /// The solution index within the block at which the builder attempted to apply the solution.
+    pub attempt_solution_ix: u32,
+    /// An error message describing why the builder failed to apply the solution.
+    pub err_msg: std::borrow::Cow<'a, str>,
+}

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-builder"
 description = "A block builder library implementation for the Essential protocol"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 essential-check = { workspace = true }
 essential-builder-db = { workspace = true }
+essential-builder-types = { workspace = true }
 essential-hash = { workspace = true }
 essential-node = { workspace = true }
 essential-node-db = { workspace = true }

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -6,7 +6,8 @@ use error::{
     BuildBlockError, CheckSolutionError, CheckSolutionsError, InvalidSolution,
     LastBlockHeaderError, SolutionPredicatesError,
 };
-use essential_builder_db::{self as builder_db, SolutionFailure};
+use essential_builder_db::{self as builder_db};
+use essential_builder_types::SolutionFailure;
 use essential_check::{self as check, solution::CheckPredicateConfig, state_read_vm::Gas};
 use essential_node as node;
 use essential_node_db as node_db;


### PR DESCRIPTION
Bumps versions of `essential-builder`, `essential-builder-api` and `essential-builder-db` for re-publishing.

Closes #26 